### PR TITLE
Implement department-specific 24-hour request limits

### DIFF
--- a/backend/routes/docs.js
+++ b/backend/routes/docs.js
@@ -52,7 +52,7 @@ router.get('/', (req, res) => {
             type_id: "number",
             content: "string (max 300 chars)"
           },
-          notes: "One request per 24 hours per student"
+          notes: "One request per 24 hours per student per department"
         },
         "PUT /api/requests/:id/status": {
           description: "Update request status (admin only)",


### PR DESCRIPTION
Implement a per-department 24-hour cooldown for student requests, allowing submissions to different departments concurrently.

---
<a href="https://cursor.com/background-agent?bcId=bc-d92653b4-8f86-4846-9242-d2e9ca099ce0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d92653b4-8f86-4846-9242-d2e9ca099ce0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

